### PR TITLE
test: update Jest config for Next.js App Router

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,7 +8,9 @@ const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.cjs'],
   moduleNameMapper: {
     '^@/components/(.*)$': '<rootDir>/components/$1',
-    '^@/pages/(.*)$': '<rootDir>/pages/$1',
+    '^@/app/(.*)$': '<rootDir>/app/$1',
+    '^@/lib/(.*)$': '<rootDir>/lib/$1',
+    '^@/styles/(.*)$': '<rootDir>/styles/$1',
   },
   testEnvironment: 'jest-environment-jsdom',
 };


### PR DESCRIPTION
- Replace `@/pages/*` alias with `@/app/*`
- Keep `@/components/*` alias
- (Optional) add mappers for `@/lib/*` and `@/styles/*`
- Preserve jsdom environment and setup files

Adapts tests to the App Router file structure in Next.js 13-15